### PR TITLE
fix syntax in bibtex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please use the following bibtex entry to cite [qFALL-crypto](https://github.com/
 
 ```text
 @misc{qFALL-crypto,
-    author = {Porzenheim, Laurens and Beckmann, Marvin and Kramer, Paul and Milewski, Phil and Moog, Sven and Schmidt, Marcel and Siemer, Niklas}
+    author = {Porzenheim, Laurens and Beckmann, Marvin and Kramer, Paul and Milewski, Phil and Moog, Sven and Schmidt, Marcel and Siemer, Niklas},
     title = {qFALL-crypto v0.0},
     howpublished = {Online: \url{https://github.com/qfall/crypto}},
     month = Mar,


### PR DESCRIPTION
The bibtex entry is missing a comma after the author list.
Curiously, the citation is correct in https://github.com/qfall/math.